### PR TITLE
Add color-coded calendar rendering and event list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
-read
+# Emoji Calendar
+
+A lightweight calendar application with a Node.js backend. Create custom emoji-powered categories, add events with colors, and browse everything on a modern monthly calendar view.
+
+## Project structure
+
+```
+calendar/
+├── client/      # Static front-end (vanilla JS, HTML, CSS)
+└── server/      # Node.js backend with JSON persistence
+```
+
+## Features
+
+- Emoji-powered categories with configurable colors.
+- Month view calendar that renders each event directly on the grid with its category accent.
+- Scrollable event list that summarizes upcoming plans with dates, categories, and notes.
+- Create events with optional descriptions and date ranges from the sidebar form.
+
+## Getting started
+
+1. Install dependencies (none required beyond Node.js 18+, but running `npm install` in
+   `server/` will create a lockfile for deployment platforms that expect one).
+2. Start the backend server from the repo root:
+
+   ```bash
+   npm start
+   ```
+
+   The API and static site are served from `http://localhost:4000` by default.
+
+3. Open a browser to `http://localhost:4000` to use the calendar UI.
+
+To host the client separately from the backend, update the `API_BASE` constant near the
+top of `client/main.js` to the deployed API origin (e.g., `https://your-domain.com`).
+
+## API overview
+
+- `GET /api/categories` – list existing categories.
+- `POST /api/categories` – create a category with `{ name, emoji, color }`.
+- `GET /api/events` – list events (each includes its category data).
+- `POST /api/events` – create an event with `{ title, startDate, endDate?, description?, categoryId }`.
+- `PUT /api/events/:id` – update an event.
+- `DELETE /api/events/:id` – remove an event.
+
+## Data storage
+
+Data is stored in `server/data.json`, which is created automatically on first run with a few sample categories. The application does not use an external database by default; the JSON file acts as the persistence layer. If you need cloud storage, point the server at a managed database or mount a persistent volume that keeps `data.json` between deployments.
+
+## Deployment guidance
+
+### Railway
+
+Railway can run the backend directly. Add a new service that deploys this
+repository and set the **Start Command** to `npm start` (or `./start.sh` if you
+prefer to call the script directly) so the platform runs the helper script
+committed at the repo root. The script changes into the `server/` directory,
+installs dependencies if needed, and starts the Node.js process. Expose port
+`4000` (or override it with the `PORT` environment variable) and mount a
+persistent volume to `server/data.json` so event data survives restarts.
+
+Railway (and similar hosts) inject a `PORT` environment variable such as `8080`;
+the server automatically honors that value, which is why the logs read
+`Server running at http://localhost:8080`. You do not need to change any other
+configuration—just make sure the client points at the public URL Railway assigns
+to your service.
+
+The `start.sh` script also works for other platforms that allow a shell entrypoint
+(e.g., Fly.io, Render, custom Docker images). It ensures dependencies are installed
+before executing `npm start`, so you can use it for local smoke tests as well:
+
+```bash
+./start.sh
+```
+
+Deploy the static client separately (e.g., via Netlify/Vercel) and point the
+`API_BASE` constant in `client/main.js` at the Railway service URL.
+
+### Netlify (static front-end only)
+
+Netlify can host the `client/` folder, but it cannot run the Node.js server that powers
+the API. Deploy the backend to a platform that supports long-lived Node processes
+(Render, Railway, Fly.io, etc.) and update the front-end to call that URL.
+
+- **Runtime**: Node 18.
+- **Base / Package directory**: leave blank (Netlify will use the repo root).
+- **Build command**: leave blank; the client assets are already built.
+- **Publish directory**: `client`.
+- **Functions directory**: leave blank unless you rewrite the backend into
+  Netlify Functions.
+
+Once the backend is deployed, set the `API_BASE` constant in `client/main.js` to the
+backend’s public URL and redeploy the static site.
+
+### Vercel
+
+Vercel’s default hosting model is also serverless/static and cannot run the existing
+`server/index.js` process as-is. You have two options:
+
+1. **Host the backend elsewhere** (Render, Railway, Fly.io, etc.) and deploy only the
+   static `client/` directory to Vercel. Use the “Other” framework preset with:
+
+   - **Build command**: leave blank.
+   - **Output directory**: `client`.
+
+   Update `API_BASE` in `client/main.js` to point at the external backend URL.
+
+2. **Refactor the backend into Vercel Functions** by moving each REST endpoint into a
+   serverless function and replacing the Node server. This requires significant code
+   changes and persistent storage that Vercel alone does not provide; you would need an
+   external database instead of the local `data.json` file.
+
+## Development tips
+
+- The client is static; changes to HTML/CSS/JS require a browser refresh.
+- The server automatically seeds default categories if no data file is present.
+- Adjust the port by setting the `PORT` environment variable before running `npm start`.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Emoji Calendar</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Emoji Calendar</h1>
+    <div class="month-switcher">
+      <button id="prev-month" aria-label="Previous month">◀</button>
+      <div id="current-month" aria-live="polite"></div>
+      <button id="next-month" aria-label="Next month">▶</button>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="calendar-card">
+      <div class="weekday-row" id="weekday-row"></div>
+      <div class="calendar-grid" id="calendar-grid" aria-live="polite"></div>
+    </section>
+
+    <section class="sidebar">
+      <section class="card">
+        <h2>Event List</h2>
+        <div class="event-feed" id="event-list-panel" aria-live="polite"></div>
+      </section>
+
+      <section class="card">
+        <h2>Add Event</h2>
+        <form id="event-form" class="stack">
+          <label>
+            Title
+            <input type="text" name="title" required />
+          </label>
+          <label>
+            Date
+            <input type="date" name="startDate" required />
+          </label>
+          <label>
+            End date
+            <input type="date" name="endDate" />
+          </label>
+          <label>
+            Category
+            <select name="categoryId" id="category-select" required></select>
+          </label>
+          <label>
+            Description
+            <textarea name="description" rows="3" placeholder="Optional details..."></textarea>
+          </label>
+          <button type="submit">Save event</button>
+          <p class="form-feedback" id="event-feedback" role="alert"></p>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Create Category</h2>
+        <form id="category-form" class="stack">
+          <label>
+            Name
+            <input type="text" name="name" required />
+          </label>
+          <label>
+            Emoji
+            <input type="text" name="emoji" maxlength="2" placeholder="😊" required />
+          </label>
+          <label>
+            Color
+            <input type="color" name="color" value="#6c5ce7" required />
+          </label>
+          <button type="submit">Add category</button>
+          <p class="form-feedback" id="category-feedback" role="alert"></p>
+        </form>
+        <div class="category-list" id="category-list"></div>
+      </section>
+    </section>
+  </main>
+
+  <template id="event-template">
+    <div class="event-pill">
+      <span class="emoji"></span>
+      <span class="text"></span>
+    </div>
+  </template>
+
+  <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,373 @@
+const weekdayRow = document.getElementById('weekday-row');
+const calendarGrid = document.getElementById('calendar-grid');
+const currentMonthLabel = document.getElementById('current-month');
+const prevMonthBtn = document.getElementById('prev-month');
+const nextMonthBtn = document.getElementById('next-month');
+const eventForm = document.getElementById('event-form');
+const eventFeedback = document.getElementById('event-feedback');
+const categoryForm = document.getElementById('category-form');
+const categoryFeedback = document.getElementById('category-feedback');
+const categorySelect = document.getElementById('category-select');
+const categoryList = document.getElementById('category-list');
+const eventTemplate = document.getElementById('event-template');
+const eventListPanel = document.getElementById('event-list-panel');
+
+const API_BASE = '';
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+let currentDate = new Date();
+let categories = [];
+let events = [];
+
+WEEKDAYS.forEach(day => {
+  const span = document.createElement('span');
+  span.textContent = day;
+  weekdayRow.appendChild(span);
+});
+
+async function fetchJSON(url, options = {}) {
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    ...options
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(payload.error || 'Request failed');
+  }
+
+  return response.json();
+}
+
+async function loadCategories() {
+  categories = await fetchJSON(`${API_BASE}/api/categories`);
+  renderCategories();
+  populateCategorySelect();
+}
+
+async function loadEvents() {
+  events = await fetchJSON(`${API_BASE}/api/events`);
+  renderCalendar();
+  renderEventList();
+}
+
+function populateCategorySelect() {
+  categorySelect.innerHTML = '';
+  categories.forEach(category => {
+    const option = document.createElement('option');
+    option.value = category.id;
+    option.textContent = `${category.emoji} ${category.name}`;
+    categorySelect.appendChild(option);
+  });
+}
+
+function renderCategories() {
+  categoryList.innerHTML = '';
+  categories.forEach(category => {
+    const item = document.createElement('div');
+    item.className = 'category-item';
+
+    const swatch = document.createElement('div');
+    swatch.className = 'category-swatch';
+    swatch.style.background = category.color;
+
+    const info = document.createElement('div');
+    info.className = 'category-info';
+    const name = document.createElement('span');
+    name.textContent = `${category.emoji} ${category.name}`;
+    const color = document.createElement('span');
+    color.textContent = category.color;
+
+    info.appendChild(name);
+    info.appendChild(color);
+
+    item.appendChild(swatch);
+    item.appendChild(info);
+    categoryList.appendChild(item);
+  });
+}
+
+function formatMonthLabel(date) {
+  return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+}
+
+function startOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function endOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function getCalendarDays(date) {
+  const firstDay = startOfMonth(date);
+  const lastDay = endOfMonth(date);
+  const startWeekday = firstDay.getDay();
+  const daysInMonth = lastDay.getDate();
+
+  const days = [];
+
+  const previousMonthLastDate = new Date(date.getFullYear(), date.getMonth(), 0).getDate();
+  for (let i = startWeekday - 1; i >= 0; i--) {
+    const day = previousMonthLastDate - i;
+    const displayDate = new Date(date.getFullYear(), date.getMonth() - 1, day);
+    days.push({ date: displayDate, outside: true });
+  }
+
+  for (let i = 1; i <= daysInMonth; i++) {
+    days.push({ date: new Date(date.getFullYear(), date.getMonth(), i), outside: false });
+  }
+
+  const remaining = 42 - days.length;
+  for (let i = 1; i <= remaining; i++) {
+    const displayDate = new Date(date.getFullYear(), date.getMonth() + 1, i);
+    days.push({ date: displayDate, outside: true });
+  }
+
+  return days;
+}
+
+function isSameDay(a, b) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function renderCalendar() {
+  currentMonthLabel.textContent = formatMonthLabel(currentDate);
+  calendarGrid.innerHTML = '';
+
+  const today = new Date();
+  const days = getCalendarDays(currentDate);
+
+  days.forEach(({ date, outside }) => {
+    const cell = document.createElement('div');
+    cell.className = 'day-cell';
+    if (outside) {
+      cell.classList.add('outside-month');
+    }
+    if (isSameDay(date, today)) {
+      cell.classList.add('today');
+    }
+
+    const dayNumber = document.createElement('div');
+    dayNumber.className = 'day-number';
+    dayNumber.textContent = date.getDate();
+    cell.appendChild(dayNumber);
+
+    const eventContainer = document.createElement('div');
+    eventContainer.className = 'event-list';
+
+    const dayEvents = events.filter(event => {
+      const start = new Date(event.startDate);
+      const end = new Date(event.endDate || event.startDate);
+      return start <= date && date <= end;
+    });
+
+    const colors = dayEvents
+      .map(event => event.category?.color)
+      .filter(Boolean);
+    if (colors.length > 0) {
+      applyDayAccent(cell, colors);
+    }
+
+    dayEvents.forEach(event => {
+      const pill = eventTemplate.content.firstElementChild.cloneNode(true);
+      const emojiSpan = pill.querySelector('.emoji');
+      const textSpan = pill.querySelector('.text');
+      const color = event.category?.color || '#cbd5f5';
+      const emoji = event.category?.emoji || '📌';
+
+      pill.style.background = color;
+      emojiSpan.textContent = emoji;
+      textSpan.textContent = event.title;
+      eventContainer.appendChild(pill);
+    });
+
+    cell.appendChild(eventContainer);
+    calendarGrid.appendChild(cell);
+  });
+}
+
+function applyDayAccent(cell, colors) {
+  const [primary] = colors;
+  cell.classList.add('has-events');
+  cell.style.setProperty('--event-accent', primary);
+  cell.style.setProperty('--event-accent-soft', hexToRgba(primary, 0.35));
+
+  if (colors.length > 1) {
+    const secondary = colors[1];
+    const gradient = `linear-gradient(135deg, ${hexToRgba(primary, 0.4)} 0%, ${hexToRgba(
+      secondary,
+      0.25
+    )} 55%, rgba(30, 41, 59, 0.92) 100%)`;
+    cell.style.background = gradient;
+  }
+}
+
+function renderEventList() {
+  if (!eventListPanel) return;
+  eventListPanel.innerHTML = '';
+
+  if (!events.length) {
+    return;
+  }
+
+  const sorted = [...events].sort((a, b) => {
+    const startDiff = new Date(a.startDate) - new Date(b.startDate);
+    if (startDiff !== 0) {
+      return startDiff;
+    }
+    return new Date(a.endDate || a.startDate) - new Date(b.endDate || b.startDate);
+  });
+
+  sorted.forEach(event => {
+    const item = document.createElement('article');
+    item.className = 'event-list-item';
+    const accent = event.category?.color || '#38bdf8';
+    item.style.setProperty('--event-accent', accent);
+    item.style.setProperty('--event-accent-soft', hexToRgba(accent, 0.25));
+
+    const titleRow = document.createElement('div');
+    titleRow.className = 'event-title';
+    const emojiSpan = document.createElement('span');
+    emojiSpan.className = 'emoji';
+    emojiSpan.textContent = event.category?.emoji || '📌';
+    const titleText = document.createElement('span');
+    titleText.textContent = event.title;
+    titleRow.appendChild(emojiSpan);
+    titleRow.appendChild(titleText);
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'event-meta';
+    const dateLabel = document.createElement('span');
+    dateLabel.textContent = formatDateRange(event.startDate, event.endDate);
+    const categoryLabel = document.createElement('span');
+    categoryLabel.textContent = event.category ? event.category.name : 'Uncategorized';
+    metaRow.appendChild(dateLabel);
+    metaRow.appendChild(categoryLabel);
+
+    item.appendChild(titleRow);
+    item.appendChild(metaRow);
+
+    if (event.description) {
+      const description = document.createElement('p');
+      description.className = 'event-description';
+      description.textContent = event.description;
+      item.appendChild(description);
+    }
+
+    eventListPanel.appendChild(item);
+  });
+}
+
+function formatDateRange(startDate, endDate) {
+  const start = new Date(startDate);
+  const end = new Date(endDate || startDate);
+  const sameDay = start.toDateString() === end.toDateString();
+  const options = { month: 'short', day: 'numeric' };
+  if (sameDay) {
+    return start.toLocaleDateString(undefined, options);
+  }
+  return `${start.toLocaleDateString(undefined, options)} → ${end.toLocaleDateString(
+    undefined,
+    options
+  )}`;
+}
+
+function hexToRgba(hex, alpha = 1) {
+  if (!hex) {
+    return `rgba(148, 163, 184, ${alpha})`;
+  }
+  let sanitized = hex.replace('#', '');
+  if (sanitized.length === 3) {
+    sanitized = sanitized
+      .split('')
+      .map(ch => ch + ch)
+      .join('');
+  }
+  if (sanitized.length !== 6) {
+    return `rgba(148, 163, 184, ${alpha})`;
+  }
+  const bigint = parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+prevMonthBtn.addEventListener('click', () => {
+  currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
+  renderCalendar();
+});
+
+nextMonthBtn.addEventListener('click', () => {
+  currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1);
+  renderCalendar();
+});
+
+eventForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  eventFeedback.textContent = '';
+  eventFeedback.classList.remove('success');
+
+  const formData = new FormData(eventForm);
+  const payload = Object.fromEntries(formData.entries());
+  if (!payload.endDate) {
+    delete payload.endDate;
+  }
+
+  try {
+    const created = await fetchJSON(`${API_BASE}/api/events`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    events.push(created);
+    renderCalendar();
+    renderEventList();
+    eventForm.reset();
+    populateCategorySelect();
+    eventFeedback.textContent = 'Event saved!';
+    eventFeedback.classList.add('success');
+  } catch (error) {
+    eventFeedback.textContent = error.message;
+  }
+});
+
+categoryForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  categoryFeedback.textContent = '';
+  categoryFeedback.classList.remove('success');
+
+  const formData = new FormData(categoryForm);
+  const payload = Object.fromEntries(formData.entries());
+
+  try {
+    const created = await fetchJSON(`${API_BASE}/api/categories`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    categories.push(created);
+    populateCategorySelect();
+    renderCategories();
+    categoryForm.reset();
+    categoryFeedback.textContent = 'Category added!';
+    categoryFeedback.classList.add('success');
+  } catch (error) {
+    categoryFeedback.textContent = error.message;
+  }
+});
+
+async function init() {
+  try {
+    await loadCategories();
+    await loadEvents();
+  } catch (error) {
+    eventFeedback.textContent = error.message;
+  }
+
+  const today = new Date();
+  eventForm.startDate.valueAsDate = today;
+}
+
+init();

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,346 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.35), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.25), transparent 50%),
+    #0f172a;
+}
+
+.app-header {
+  padding: 1.5rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.app-header h1 {
+  font-size: 2rem;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+
+.month-switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+}
+
+.month-switcher button {
+  background: rgba(148, 163, 184, 0.15);
+  border: none;
+  color: inherit;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.month-switcher button:hover {
+  background: rgba(148, 163, 184, 0.35);
+  transform: translateY(-1px);
+}
+
+#current-month {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(260px, 1fr);
+  gap: 2rem;
+  padding: 0 2rem 2rem;
+}
+
+.calendar-card {
+  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.weekday-row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.75rem;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.day-cell {
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 18px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 120px;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+}
+
+.day-cell.has-events {
+  background: linear-gradient(135deg, var(--event-accent-soft, rgba(148, 163, 184, 0.35)) 0%, rgba(30, 41, 59, 0.9) 100%);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.4), inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.day-cell.outside-month {
+  opacity: 0.35;
+}
+
+.day-number {
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+}
+
+.day-cell.has-events .day-number {
+  color: var(--event-accent, #fbbf24);
+}
+
+.today .day-number {
+  color: #fbbf24;
+}
+
+.event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.event-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #0f172a;
+  background: #f1f5f9;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.event-pill .emoji {
+  font-size: 1rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.event-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  max-height: clamp(16rem, 40vh, 22rem);
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.event-feed:empty::before {
+  content: 'No events yet — add one to get started!';
+  color: rgba(148, 163, 184, 0.75);
+  font-style: italic;
+}
+
+.event-list-item {
+  --event-accent: rgba(148, 163, 184, 0.65);
+  --event-accent-soft: rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 0.75rem 0.9rem;
+  display: grid;
+  gap: 0.45rem;
+  background: linear-gradient(135deg, var(--event-accent-soft) 0%, rgba(15, 23, 42, 0.85) 100%);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.event-list-item .event-title {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.event-list-item .event-title .emoji {
+  font-size: 1.25rem;
+}
+
+.event-list-item .event-meta {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.event-list-item .event-description {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+  margin: 0;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.4);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+input,
+select,
+textarea,
+button {
+  border-radius: 12px;
+  border: none;
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+textarea {
+  resize: vertical;
+}
+
+button[type='submit'] {
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  box-shadow: 0 15px 30px rgba(99, 102, 241, 0.35);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button[type='submit']:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(99, 102, 241, 0.45);
+}
+
+.form-feedback {
+  min-height: 1.5rem;
+  font-size: 0.85rem;
+  color: #f87171;
+}
+
+.form-feedback.success {
+  color: #34d399;
+}
+
+.category-list {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.category-item {
+  background: rgba(30, 41, 59, 0.75);
+  border-radius: 16px;
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.category-swatch {
+  width: 14px;
+  height: 60px;
+  border-radius: 10px;
+}
+
+.category-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.category-info span:first-child {
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    flex: 1 1 320px;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .layout {
+    padding: 0 1.25rem 1.25rem;
+  }
+
+  .calendar-grid {
+    gap: 0.5rem;
+  }
+
+  .day-cell {
+    padding: 0.6rem;
+    min-height: 100px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "calendar-app",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Calendar web app with Node backend",
+  "scripts": {
+    "start": "./start.sh",
+    "server": "node server/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/server/data.json
+++ b/server/data.json
@@ -1,0 +1,23 @@
+{
+  "categories": [
+    {
+      "id": "default-personal",
+      "name": "Personal",
+      "emoji": "🏡",
+      "color": "#4caf50"
+    },
+    {
+      "id": "default-work",
+      "name": "Work",
+      "emoji": "💼",
+      "color": "#2196f3"
+    },
+    {
+      "id": "default-social",
+      "name": "Social",
+      "emoji": "🎉",
+      "color": "#ff9800"
+    }
+  ],
+  "events": []
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,307 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
+const PORT = process.env.PORT || 4000;
+const DATA_FILE = path.join(__dirname, 'data.json');
+const CLIENT_DIR = path.join(__dirname, '..', 'client');
+
+function ensureDataFile() {
+  if (!fs.existsSync(DATA_FILE)) {
+    const initial = {
+      categories: [
+        { id: 'default-personal', name: 'Personal', emoji: '🏡', color: '#4caf50' },
+        { id: 'default-work', name: 'Work', emoji: '💼', color: '#2196f3' },
+        { id: 'default-social', name: 'Social', emoji: '🎉', color: '#ff9800' }
+      ],
+      events: []
+    };
+    fs.writeFileSync(DATA_FILE, JSON.stringify(initial, null, 2));
+  }
+}
+
+function readData() {
+  ensureDataFile();
+  const raw = fs.readFileSync(DATA_FILE, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS'
+  });
+  res.end(body);
+}
+
+function sendError(res, status, message) {
+  sendJson(res, status, { error: message });
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk.toString();
+      if (data.length > 1e6) {
+        req.socket.destroy();
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!data) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(new Error('Invalid JSON body'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function validateCategory(input) {
+  if (!input || typeof input !== 'object') {
+    return 'Category must be an object';
+  }
+  const { name, emoji, color } = input;
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return 'Category name is required';
+  }
+  if (!emoji || typeof emoji !== 'string') {
+    return 'Category emoji is required';
+  }
+  if (!color || typeof color !== 'string' || !/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(color)) {
+    return 'Category color must be a hex value like #ff0000';
+  }
+  return null;
+}
+
+function validateEvent(input, categories) {
+  if (!input || typeof input !== 'object') {
+    return 'Event must be an object';
+  }
+  const { title, description, startDate, endDate, categoryId } = input;
+  if (!title || typeof title !== 'string' || !title.trim()) {
+    return 'Event title is required';
+  }
+  const start = new Date(startDate);
+  if (!startDate || Number.isNaN(start.getTime())) {
+    return 'Valid startDate is required';
+  }
+  if (endDate) {
+    const end = new Date(endDate);
+    if (Number.isNaN(end.getTime())) {
+      return 'endDate must be a valid date when provided';
+    }
+    if (end < start) {
+      return 'endDate cannot be before startDate';
+    }
+  }
+  if (!categoryId || !categories.find(cat => cat.id === categoryId)) {
+    return 'A valid categoryId is required';
+  }
+  if (description && typeof description !== 'string') {
+    return 'Description must be a string when provided';
+  }
+  return null;
+}
+
+function handleApi(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS'
+    });
+    res.end();
+    return true;
+  }
+
+  if (url.pathname === '/api/categories' && req.method === 'GET') {
+    const data = readData();
+    sendJson(res, 200, data.categories);
+    return true;
+  }
+
+  if (url.pathname === '/api/categories' && req.method === 'POST') {
+    parseBody(req)
+      .then(body => {
+        const error = validateCategory(body);
+        if (error) {
+          sendError(res, 400, error);
+          return;
+        }
+        const data = readData();
+        const newCategory = {
+          id: randomUUID(),
+          name: body.name.trim(),
+          emoji: body.emoji,
+          color: body.color
+        };
+        data.categories.push(newCategory);
+        writeData(data);
+        sendJson(res, 201, newCategory);
+      })
+      .catch(err => {
+        sendError(res, 400, err.message);
+      });
+    return true;
+  }
+
+  if (url.pathname === '/api/events' && req.method === 'GET') {
+    const data = readData();
+    const eventsWithCategory = data.events.map(event => ({
+      ...event,
+      category: data.categories.find(cat => cat.id === event.categoryId) || null
+    }));
+    sendJson(res, 200, eventsWithCategory);
+    return true;
+  }
+
+  if (url.pathname === '/api/events' && req.method === 'POST') {
+    parseBody(req)
+      .then(body => {
+        const data = readData();
+        const error = validateEvent(body, data.categories);
+        if (error) {
+          sendError(res, 400, error);
+          return;
+        }
+        const newEvent = {
+          id: randomUUID(),
+          title: body.title.trim(),
+          description: body.description ? body.description.trim() : '',
+          startDate: body.startDate,
+          endDate: body.endDate || body.startDate,
+          categoryId: body.categoryId
+        };
+        data.events.push(newEvent);
+        writeData(data);
+        sendJson(res, 201, {
+          ...newEvent,
+          category: data.categories.find(cat => cat.id === newEvent.categoryId) || null
+        });
+      })
+      .catch(err => {
+        sendError(res, 400, err.message);
+      });
+    return true;
+  }
+
+  const eventIdMatch = url.pathname.match(/^\/api\/events\/([^/]+)$/);
+  if (eventIdMatch) {
+    const eventId = eventIdMatch[1];
+    if (req.method === 'PUT') {
+      parseBody(req)
+        .then(body => {
+          const data = readData();
+          const existingIndex = data.events.findIndex(event => event.id === eventId);
+          if (existingIndex === -1) {
+            sendError(res, 404, 'Event not found');
+            return;
+          }
+          const merged = { ...data.events[existingIndex], ...body };
+          const error = validateEvent(merged, data.categories);
+          if (error) {
+            sendError(res, 400, error);
+            return;
+          }
+          merged.title = merged.title.trim();
+          if (merged.description) {
+            merged.description = merged.description.trim();
+          }
+          merged.endDate = merged.endDate || merged.startDate;
+          data.events[existingIndex] = merged;
+          writeData(data);
+          sendJson(res, 200, {
+            ...merged,
+            category: data.categories.find(cat => cat.id === merged.categoryId) || null
+          });
+        })
+        .catch(err => {
+          sendError(res, 400, err.message);
+        });
+      return true;
+    }
+
+    if (req.method === 'DELETE') {
+      const data = readData();
+      const existingIndex = data.events.findIndex(event => event.id === eventId);
+      if (existingIndex === -1) {
+        sendError(res, 404, 'Event not found');
+        return true;
+      }
+      const [removed] = data.events.splice(existingIndex, 1);
+      writeData(data);
+      sendJson(res, 200, removed);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const server = http.createServer((req, res) => {
+  if (handleApi(req, res)) {
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  let filePath = path.join(CLIENT_DIR, url.pathname);
+  if (url.pathname === '/') {
+    filePath = path.join(CLIENT_DIR, 'index.html');
+  }
+
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const contentTypeMap = {
+      '.html': 'text/html',
+      '.css': 'text/css',
+      '.js': 'application/javascript',
+      '.json': 'application/json',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.svg': 'image/svg+xml',
+      '.ico': 'image/x-icon'
+    };
+    const contentType = contentTypeMap[ext] || 'application/octet-stream';
+
+    fs.readFile(filePath, (readErr, content) => {
+      if (readErr) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal Server Error');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    });
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "calendar-server",
+  "version": "1.0.0",
+  "description": "Simple calendar API server",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/server"
+
+if ! command -v node >/dev/null 2>&1; then
+  printf '%s\n' "Error: node is required but not found on PATH." >&2
+  exit 1
+fi
+
+NEED_INSTALL=0
+if [ ! -d node_modules ] && [ -f package.json ]; then
+  if grep -q '"dependencies"' package.json || grep -q '"optionalDependencies"' package.json; then
+    NEED_INSTALL=1
+  fi
+fi
+
+if [ "$NEED_INSTALL" -eq 1 ]; then
+  if command -v npm >/dev/null 2>&1; then
+    if [ -f package-lock.json ]; then
+      npm ci --omit=dev --no-audit --no-fund
+    else
+      npm install --omit=dev --no-audit --no-fund
+    fi
+  else
+    printf '%s\n' "Warning: Dependencies detected but npm is unavailable; skipping installation." >&2
+  fi
+fi
+
+PORT="${PORT:-4000}"
+export PORT
+exec node index.js


### PR DESCRIPTION
## Summary
- render category-colored event pills directly on each calendar day and tint days with event accents
- add a scrollable event list panel that surfaces upcoming plans with emoji, dates, and notes
- document the JSON-based persistence layer so users know the app does not yet use an external database

## Testing
- node --check server/index.js

------
https://chatgpt.com/codex/tasks/task_e_68dc122e31b08321a7be87de88147241