### PR TITLE
Add support for deleting categories

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -12,6 +12,7 @@ const categoryColorSelect = document.getElementById('category-color-select');
 const categoryList = document.getElementById('category-list');
 const eventTemplate = document.getElementById('event-template');
 const eventListPanel = document.getElementById('event-list-panel');
+const CATEGORY_DELETE_CONFIRMATION = 'Deleting a category will also remove all events assigned to it. Continue?';
 
 const API_BASE = '';
 
@@ -139,10 +140,51 @@ function renderCategories() {
     info.appendChild(name);
     info.appendChild(color);
 
+    const actions = document.createElement('div');
+    actions.className = 'category-actions';
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'category-delete-button';
+    deleteButton.textContent = 'Delete';
+    deleteButton.addEventListener('click', () => {
+      handleDeleteCategory(category.id);
+    });
+    actions.appendChild(deleteButton);
+
     item.appendChild(swatch);
     item.appendChild(info);
+    item.appendChild(actions);
     categoryList.appendChild(item);
   });
+}
+
+async function handleDeleteCategory(categoryId) {
+  if (!categoryId) {
+    return;
+  }
+  if (!window.confirm(CATEGORY_DELETE_CONFIRMATION)) {
+    return;
+  }
+  try {
+    await fetchJSON(`${API_BASE}/api/categories/${encodeURIComponent(categoryId)}`, {
+      method: 'DELETE'
+    });
+    categories = categories.filter(category => category.id !== categoryId);
+    renderCategories();
+    populateCategorySelect();
+    await loadEvents();
+    if (categoryFeedback) {
+      categoryFeedback.textContent = 'Category deleted successfully';
+      categoryFeedback.classList.remove('success');
+      void categoryFeedback.offsetWidth;
+      categoryFeedback.classList.add('success');
+    }
+  } catch (error) {
+    if (categoryFeedback) {
+      categoryFeedback.textContent = error.message;
+      categoryFeedback.classList.remove('success');
+    }
+  }
 }
 
 function formatMonthLabel(date) {

--- a/client/styles.css
+++ b/client/styles.css
@@ -344,6 +344,25 @@ button[type='submit']:hover {
   font-weight: 600;
 }
 
+.category-actions {
+  margin-left: auto;
+}
+
+.category-delete-button {
+  background: transparent;
+  border: none;
+  color: #fca5a5;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.category-delete-button:hover,
+.category-delete-button:focus {
+  color: #f87171;
+  outline: none;
+}
+
 @media (max-width: 1024px) {
   .layout {
     grid-template-columns: 1fr;

--- a/server/index.js
+++ b/server/index.js
@@ -225,6 +225,33 @@ function handleApi(req, res) {
     return true;
   }
 
+  const categoryIdMatch = url.pathname.match(/^\/api\/categories\/([^/]+)$/);
+  if (categoryIdMatch) {
+    const categoryId = decodeURIComponent(categoryIdMatch[1]);
+
+    if (req.method === 'DELETE') {
+      const data = readData();
+      const existingIndex = data.categories.findIndex(category => category.id === categoryId);
+      if (existingIndex === -1) {
+        sendError(res, 404, 'Category not found');
+        return true;
+      }
+      const [removedCategory] = data.categories.splice(existingIndex, 1);
+      const removedEvents = data.events.filter(event => event.categoryId === categoryId);
+      if (removedEvents.length > 0) {
+        data.events = data.events.filter(event => event.categoryId !== categoryId);
+      }
+      try {
+        writeData(data);
+      } catch (error) {
+        sendError(res, 500, error.message);
+        return true;
+      }
+      sendJson(res, 200, { category: removedCategory, removedEvents });
+      return true;
+    }
+  }
+
   if (url.pathname === '/api/events' && req.method === 'GET') {
     const data = readData();
     const eventsWithCategory = data.events.map(event => ({


### PR DESCRIPTION
## Summary
- add a DELETE /api/categories/:id endpoint that removes the category and any related events
- add a client-side control to request category deletion and refresh the calendar data
- style the category list to display the new delete action

## Testing
- npm run server

------
https://chatgpt.com/codex/tasks/task_e_6901c6dbf5148321b2efec732b869c78